### PR TITLE
handle formatMessage({ id: x }) notation

### DIFF
--- a/fixtures/react-intl/app/react/components/my-localized-component.jsx
+++ b/fixtures/react-intl/app/react/components/my-localized-component.jsx
@@ -1,10 +1,17 @@
 import { FormattedMessage, useIntl } from 'react-intl';
 
 export function MyLocalizedComponent() {
+  // legacy API
   const { t } = useIntl();
+
+  // new API
+  const intl = useIntl();
+
   return (
     <div>
       {t('hook-translation')}
+      {intl.formatMessage({ id: 'hook-translation-new' })}
+      {intl.formatMessage({ id: true ? 'hook-alternate' : 'hook-consequent'})}
       <FormattedMessage id="jsx-translation" />
     </div>
   );

--- a/fixtures/react-intl/translations/de.json
+++ b/fixtures/react-intl/translations/de.json
@@ -1,5 +1,8 @@
 {
   "jsx-translation": "JSX but in german!",
   "hook-translation": "Hook but in german!",
+  "hook-translation-new": "new hook but in german!",
+  "hook-alternate": "Ich bin in a ternary!",
+  "hook-consequent": "Ich also bin in a ternary!",
   "tsx-translation": "TSX but in german!"
 }

--- a/fixtures/react-intl/translations/en.json
+++ b/fixtures/react-intl/translations/en.json
@@ -1,5 +1,8 @@
 {
   "jsx-translation": "JSX!",
   "hook-translation": "Hook!",
+  "hook-translation-new": "new hook!",
+  "hook-alternate": "I'm in a ternary!",
+  "hook-consequent": "I'm also in a ternary!",
   "tsx-translation": "TSX!"
 }


### PR DESCRIPTION
This allows the tool to catch keys used with ``intl.formatMessage({ id: 'my.key' })` or `intl.formatMessage({ id: x ? 'my.key' : 'my.other.key' })