### PR TITLE
handle intl.formatMessage in ts files too

### DIFF
--- a/fixtures/react-intl/app/react/components/my-localized-component.jsx
+++ b/fixtures/react-intl/app/react/components/my-localized-component.jsx
@@ -1,17 +1,12 @@
 import { FormattedMessage, useIntl } from 'react-intl';
 
 export function MyLocalizedComponent() {
-  // legacy API
-  const { t } = useIntl();
-
-  // new API
   const intl = useIntl();
 
   return (
     <div>
-      {t('hook-translation')}
       {intl.formatMessage({ id: 'hook-translation-new' })}
-      {intl.formatMessage({ id: true ? 'hook-alternate' : 'hook-consequent'})}
+      {intl.formatMessage({ id: true ? 'hook-alternate' : 'hook-consequent' })}
       <FormattedMessage id="jsx-translation" />
     </div>
   );

--- a/fixtures/react-intl/app/react/hooks/my-custom-translation-hook.ts
+++ b/fixtures/react-intl/app/react/hooks/my-custom-translation-hook.ts
@@ -1,0 +1,8 @@
+import { useIntl } from 'react-intl';
+
+export function useTranslations() {
+  const intl = useIntl();
+  return {
+    'my-custom-translation-key': intl.formatMessage({ id: 'my-custom-hook-translation' }),
+  };
+}

--- a/fixtures/react-intl/translations/de.json
+++ b/fixtures/react-intl/translations/de.json
@@ -1,8 +1,8 @@
 {
   "jsx-translation": "JSX but in german!",
-  "hook-translation": "Hook but in german!",
   "hook-translation-new": "new hook but in german!",
   "hook-alternate": "Ich bin in a ternary!",
   "hook-consequent": "Ich also bin in a ternary!",
-  "tsx-translation": "TSX but in german!"
+  "tsx-translation": "TSX but in german!",
+  "my-custom-hook-translation": "I'm from a .ts file! But in german!"
 }

--- a/fixtures/react-intl/translations/en.json
+++ b/fixtures/react-intl/translations/en.json
@@ -1,8 +1,8 @@
 {
   "jsx-translation": "JSX!",
-  "hook-translation": "Hook!",
   "hook-translation-new": "new hook!",
   "hook-alternate": "I'm in a ternary!",
   "hook-consequent": "I'm also in a ternary!",
-  "tsx-translation": "TSX!"
+  "tsx-translation": "TSX!",
+  "my-custom-hook-translation": "I'm from a .ts file!"
 }

--- a/index.js
+++ b/index.js
@@ -334,33 +334,10 @@ async function analyzeJsxFile(content, userPlugins) {
         }
       }
     },
-    // store ids passed to the t function in the translationKeys set
     CallExpression({ node }) {
-      let { callee } = node;
       if (node.arguments.length === 0) return;
 
-      // handle t('foo') case
-      if (callee.type === 'Identifier' && callee.name === 't') {
-        let firstParam = node.arguments[0];
-        if (firstParam.type === 'StringLiteral') {
-          translationKeys.add(firstParam.value);
-        } else if (firstParam.type === 'ConditionalExpression') {
-          if (firstParam.alternate.type === 'StringLiteral') {
-            translationKeys.add(firstParam.alternate.value);
-          }
-          if (firstParam.consequent.type === 'StringLiteral') {
-            translationKeys.add(firstParam.consequent.value);
-          }
-        }
-      }
-      // handle intl.formatMessage({ id: 'foo' }) case
-      else if (
-        callee.type === 'MemberExpression' &&
-        callee.object.type === 'Identifier' &&
-        callee.object.name === 'intl' &&
-        callee.property.type === 'Identifier' &&
-        callee.property.name === 'formatMessage'
-      ) {
+      if (isIntlFormatMessageCall(node)) {
         let firstParam = node.arguments[0];
         if (firstParam.type === 'ObjectExpression') {
           for (let property of firstParam.properties) {
@@ -392,6 +369,25 @@ async function analyzeJsxFile(content, userPlugins) {
   return translationKeys;
 }
 
+function isIntlFormatMessageCall(node) {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === 'intl' &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'formatMessage'
+  );
+}
+
+function isTFunctionCall(node) {
+  return (
+    (node.callee.type === 'Identifier' && node.callee.name === 't') ||
+    (node.callee.type === 'MemberExpression' &&
+      node.callee.property.type === 'Identifier' &&
+      node.callee.property.name === 't')
+  );
+}
+
 async function analyzeJsFile(content, userPlugins) {
   let translationKeys = new Set();
 
@@ -404,27 +400,44 @@ async function analyzeJsFile(content, userPlugins) {
   // find translation keys in the syntax tree
   traverse(ast, {
     CallExpression({ node }) {
-      let { callee } = node;
       if (node.arguments.length === 0) return;
 
-      if (callee.type === 'MemberExpression') {
-        // handle this.intl.t('foo') case
-        if (callee.property.type !== 'Identifier') return;
-        if (callee.property.name !== 't') return;
-      } else if (callee.type === 'Identifier') {
-        // handle t('foo') case
-        if (callee.name !== 't') return;
-      } else return;
-
-      let firstParam = node.arguments[0];
-      if (firstParam.type === 'StringLiteral') {
-        translationKeys.add(firstParam.value);
-      } else if (firstParam.type === 'ConditionalExpression') {
-        if (firstParam.alternate.type === 'StringLiteral') {
-          translationKeys.add(firstParam.alternate.value);
+      if (isTFunctionCall(node)) {
+        let firstParam = node.arguments[0];
+        if (firstParam.type === 'StringLiteral') {
+          translationKeys.add(firstParam.value);
+        } else if (firstParam.type === 'ConditionalExpression') {
+          if (firstParam.alternate.type === 'StringLiteral') {
+            translationKeys.add(firstParam.alternate.value);
+          }
+          if (firstParam.consequent.type === 'StringLiteral') {
+            translationKeys.add(firstParam.consequent.value);
+          }
         }
-        if (firstParam.consequent.type === 'StringLiteral') {
-          translationKeys.add(firstParam.consequent.value);
+      } else if (isIntlFormatMessageCall(node)) {
+        let firstParam = node.arguments[0];
+        if (firstParam.type === 'ObjectExpression') {
+          for (let property of firstParam.properties) {
+            if (
+              property.type === 'ObjectProperty' &&
+              property.key.type === 'Identifier' &&
+              property.key.name === 'id'
+            ) {
+              // if it's a string literal, add it to the translationKeys set
+              if (property.value.type === 'StringLiteral') {
+                translationKeys.add(property.value.value);
+              }
+              // else, if it's a ternary operator, add the consequent and alternate to the translationKeys set
+              else if (property.value.type === 'ConditionalExpression') {
+                if (property.value.alternate.type === 'StringLiteral') {
+                  translationKeys.add(property.value.alternate.value);
+                }
+                if (property.value.consequent.type === 'StringLiteral') {
+                  translationKeys.add(property.value.consequent.value);
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/test.js
+++ b/test.js
@@ -44,8 +44,8 @@ describe('Test Fixtures', () => {
       helpers: ['t-error'],
     },
     'react-intl': {
-      extensions: ['.jsx', '.tsx'],
-    }
+      extensions: ['.jsx', '.tsx', '.ts'],
+    },
   };
 
   beforeEach(() => {


### PR DESCRIPTION
This PR makes the tool aware of `intl.formatMessage` API in non-jsx files too. This can happen when creating a custom hook in a .ts file for example, this also stops looking for `t` calls in JSX/TSX files 