### PR TITLE
 handle formatMessage identifiers

### DIFF
--- a/fixtures/react-intl/app/react/components/my-localized-component.jsx
+++ b/fixtures/react-intl/app/react/components/my-localized-component.jsx
@@ -2,9 +2,11 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 export function MyLocalizedComponent() {
   const intl = useIntl();
+  const { formatMessage } = intl;
 
   return (
     <div>
+      {formatMessage({ id: 'hook-translation-destructured' })}
       {intl.formatMessage({ id: 'hook-translation-new' })}
       {intl.formatMessage({ id: true ? 'hook-alternate' : 'hook-consequent' })}
       <FormattedMessage id="jsx-translation" />

--- a/fixtures/react-intl/translations/de.json
+++ b/fixtures/react-intl/translations/de.json
@@ -4,5 +4,6 @@
   "hook-alternate": "Ich bin in a ternary!",
   "hook-consequent": "Ich also bin in a ternary!",
   "tsx-translation": "TSX but in german!",
-  "my-custom-hook-translation": "I'm from a .ts file! But in german!"
+  "my-custom-hook-translation": "I'm from a .ts file! But in german!",
+  "hook-translation-destructured": "I'm from a destructured intl hook return! (but german)"
 }

--- a/fixtures/react-intl/translations/en.json
+++ b/fixtures/react-intl/translations/en.json
@@ -4,5 +4,6 @@
   "hook-alternate": "I'm in a ternary!",
   "hook-consequent": "I'm also in a ternary!",
   "tsx-translation": "TSX!",
-  "my-custom-hook-translation": "I'm from a .ts file!"
+  "my-custom-hook-translation": "I'm from a .ts file!",
+  "hook-translation-destructured": "I'm from a destructured intl hook return!"
 }

--- a/index.js
+++ b/index.js
@@ -371,11 +371,12 @@ async function analyzeJsxFile(content, userPlugins) {
 
 function isIntlFormatMessageCall(node) {
   return (
-    node.callee.type === 'MemberExpression' &&
-    node.callee.object.type === 'Identifier' &&
-    node.callee.object.name === 'intl' &&
-    node.callee.property.type === 'Identifier' &&
-    node.callee.property.name === 'formatMessage'
+    (node.callee.type === 'Identifier' && node.callee.name === 'formatMessage') ||
+    (node.callee.type === 'MemberExpression' &&
+      node.callee.object.type === 'Identifier' &&
+      node.callee.object.name === 'intl' &&
+      node.callee.property.type === 'Identifier' &&
+      node.callee.property.name === 'formatMessage')
   );
 }
 


### PR DESCRIPTION
This MR handles `formatMessage({ id })` in addition to `intl.formatMessage({ id })`.