### PR TITLE
exit code 1 on error

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,4 +14,5 @@ run(rootDir, { fix: process.argv.includes('--fix') })
   })
   .catch(error => {
     console.error(chalk.red(error.stack));
+    process.exitCode = 1;
   });


### PR DESCRIPTION
the command was displaying a red error message on error, but was not setting the exitCode to 1, making the command succeed even on crash. This MR updates this behaviour.