### PR TITLE
Add support for `FormattedHTMLMessage` component

### DIFF
--- a/fixtures/react-intl/app/react/components/my-localized-component.jsx
+++ b/fixtures/react-intl/app/react/components/my-localized-component.jsx
@@ -10,6 +10,7 @@ export function MyLocalizedComponent() {
       {intl.formatMessage({ id: 'hook-translation-new' })}
       {intl.formatMessage({ id: true ? 'hook-alternate' : 'hook-consequent' })}
       <FormattedMessage id="jsx-translation" />
+      <FormattedHTMLMessage id="jsx-translation-html" />
     </div>
   );
 }

--- a/fixtures/react-intl/app/react/components/my-ts-localized-component.tsx
+++ b/fixtures/react-intl/app/react/components/my-ts-localized-component.tsx
@@ -4,6 +4,7 @@ export function MyLocalizedComponent(): JSX.Element {
   return (
     <div>
       <FormattedMessage id="tsx-translation" />
+      <FormattedHTMLMessage id="jsx-translation-html" />
     </div>
   );
 }

--- a/fixtures/react-intl/translations/de.json
+++ b/fixtures/react-intl/translations/de.json
@@ -1,5 +1,6 @@
 {
   "jsx-translation": "JSX but in german!",
+  "jsx-translation-html": "<em>JSX but in german!</em>",
   "hook-translation-new": "new hook but in german!",
   "hook-alternate": "Ich bin in a ternary!",
   "hook-consequent": "Ich also bin in a ternary!",

--- a/fixtures/react-intl/translations/en.json
+++ b/fixtures/react-intl/translations/en.json
@@ -1,5 +1,6 @@
 {
   "jsx-translation": "JSX!",
+  "jsx-translation-html": "<em>JSX!</em>",
   "hook-translation-new": "new hook!",
   "hook-alternate": "I'm in a ternary!",
   "hook-consequent": "I'm also in a ternary!",

--- a/index.js
+++ b/index.js
@@ -308,10 +308,13 @@ async function analyzeJsxFile(content, userPlugins) {
     plugins: ['jsx', 'typescript', 'dynamicImport', ...userPlugins],
   });
 
-  // store ids passed to the <FormattedMessage> component in the translationKeys set
+  // store ids passed to the <FormattedMessage> and <FormattedHTMLMessage> components in the translationKeys set
   traverse(ast, {
     JSXOpeningElement({ node }) {
-      if (node.name.type === 'JSXIdentifier' && node.name.name === 'FormattedMessage') {
+      if (
+        node.name.type === 'JSXIdentifier' &&
+        ['FormattedMessage', 'FormattedHTMLMessage'].includes(node.name.name)
+      ) {
         for (let attribute of node.attributes) {
           if (
             attribute.type === 'JSXAttribute' &&


### PR DESCRIPTION
The aim of this PR is adding support for the custom `FormattedHTMLMessage` component.

It was created to render strings with HTML markup and it wraps around `FormattedMessaged`.

Since it's not picked up by `ember-intl-analyzer`, it bloats the allow list with unnecessary entries.