### PR TITLE
Add support for Qonto kits

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ function readConfig(cwd) {
 
 async function findAppFiles(cwd, userExtensions) {
   let extensions = [...DEFAULT_EXTENSIONS, ...userExtensions];
-  let pathsWithExtensions = extensions.map(extension => 'app/**/*' + extension);
+  let pathsWithExtensions = extensions.map(extension => '{app,src}/**/*' + extension);
   return globby(pathsWithExtensions, { cwd });
 }
 


### PR DESCRIPTION
The aim of this PR is tweaking `ember-intl-analyzer` so that it can be used in Qonto kits as well.

It's addding support for a `src` folder alongside `app`, since that's the naming we're using in kits.

The changes were tested on the `cards-kit`