### PR TITLE
Add support for `.cjs` extension for config file

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ async function run(rootDir, options = {}) {
 }
 
 function readConfig(cwd) {
-  let configPath = `${cwd}/config/ember-intl-analyzer.js`;
+  let configPath = (globby.sync(`${cwd}/config/ember-intl-analyzer.{js,cjs}`))[0];
 
   let config = {};
   if (fs.existsSync(configPath)) {


### PR DESCRIPTION
The aim of this PR is adding support for the `.cjs` extension for the config file.

This is the extension required by packages configured as ES modules, e.g. the `cards-kit`.

The change was tested both on `qonto-js` and `cards-kit`.