### PR TITLE
Add support for external templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ async function run(rootDir, options = {}) {
   let ignoredAppFiles = config.ignoredAppFiles || [];
   let customHelpers = config.helpers || [];
   let includeGtsExtension = userExtensions.includes('.gts');
+  let externalTemplatesPaths = config.externalTemplatesPaths || [];
 
   userExtensions = userExtensions.map(extension =>
     extension.startsWith('.') ? extension : `.${extension}`
@@ -48,13 +49,18 @@ async function run(rootDir, options = {}) {
     helpers: customHelpers,
   };
 
-  log(`${step(1)} 🔍  Finding JS and HBS files...`);
+  log(`${step(1)} 🔍  Finding files containing translations...`);
   let appFiles = await findAppFiles(rootDir, userExtensions, ignoredAppFiles);
   let inRepoFiles = await findInRepoFiles(rootDir, userExtensions);
   let files = [...appFiles, ...inRepoFiles];
 
-  log(`${step(2)} 🔍  Searching for translations keys in JS and HBS files...`);
-  let usedTranslationKeys = await analyzeFiles(rootDir, files, analyzeOptions);
+  let externalFiles = await findExternalFiles(rootDir, externalTemplatesPaths, userExtensions);
+
+
+  log(`${step(2)} 🔍  Searching for translations keys in your files...`);
+  let localTranslationKeys =  await analyzeFiles(rootDir, files, analyzeOptions);
+  let externalTranslationKeys = await analyzeFiles('', externalFiles, analyzeOptions);
+  let usedTranslationKeys = new Map([...localTranslationKeys, ...externalTranslationKeys]);
 
   log(`${step(3)} ⚙️   Checking for unused translations...`);
 
@@ -171,6 +177,23 @@ async function findInRepoFiles(cwd, userExtensions) {
   let pathsWithExtensions = extensions.map(extension => `**/*${extension}`);
 
   return globby(joinPaths(inRepoFolders, pathsWithExtensions), { cwd });
+}
+
+async function findExternalFiles(cwd, externalTemplatesPaths, userExtensions) {
+  if (externalTemplatesPaths.length === 0)  return [];
+
+  let baseUrl = path.join(cwd.split('qonto-web')[0], "qonto-web");
+  let extensions = [...DEFAULT_EXTENSIONS, ...userExtensions];
+
+  let files = []
+  for (let externalTemplatesPath of externalTemplatesPaths) {
+    let templatePath = path.join(baseUrl, externalTemplatesPath);
+    let pathsWithExtensions = extensions.map(extension => `{app,src}/**/*${extension}`);
+
+    let fullPaths = await globby(joinPaths(templatePath, pathsWithExtensions))
+    files.push(...fullPaths);
+  }
+  return files;
 }
 
 async function findOwnTranslationFiles(cwd, config) {


### PR DESCRIPTION
This PR proposes a new `externalTemplates` configuration option.

Contrary to [externalPaths](https://github.com/mainmatter/ember-intl-analyzer?tab=readme-ov-file#externalpaths), which allows users to include copies from an external source, `externalTemplates` allows users to include templates from an external source.

This is necessary to move the kits (e.g. `cards-kit`) copies to `qonto-js`, as per our desidered architecture, see https://qonto.slack.com/archives/C05F2DR6H4P/p1750838859015319

The changes can be tested by checking out this [branch](https://github.com/qonto-private/qonto-web/pull/7358) and running `pnpm run lint:unused-translations` in `qonto-js` with and without the config option.